### PR TITLE
Feature/ple 3602 go 1x runtime deprecated ssosyncv2 2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-OUTPUT = main # Referenced as Handler in template.yaml
+OUTPUT = bootstrap # Referenced as Handler in template.yaml
 RELEASER = goreleaser
 PACKAGED_TEMPLATE = packaged.yaml
 STACK_NAME := ssosyncv2
@@ -16,25 +16,28 @@ test:
 go-build:
 	go build -o $(APP_NAME) main.go
 
-build-SSOSyncFunction:
+build-SSOSyncV2Function:
 	GOOS=linux GOARCH=arm64 go build -o bootstrap main.go
 	cp ./bootstrap $(ARTIFACTS_DIR)/.
 
 .PHONY: clean
 clean:
 	rm -f $(OUTPUT) $(PACKAGED_TEMPLATE)
+	rm -rf .aws-sam/
 
 .PHONY: install
 install:
 	go get ./...
 
-main: main.go
-	goreleaser build --snapshot --rm-dist
+# Build for Lambda (ARM64 Linux)
+.PHONY: lambda-build
+lambda-build:
+	GOOS=linux GOARCH=arm64 go build -o bootstrap main.go
 
 # compile the code to run in Lambda (local or real)
 .PHONY: lambda
 lambda:
-	$(MAKE) main
+	$(MAKE) lambda-build
 
 .PHONY: build
 build: clean lambda

--- a/README.md
+++ b/README.md
@@ -12,6 +12,4 @@ Fork of https://github.com/awslabs/ssosync.
 ### Steps
 
 1. Sign into the zn-master account with your AWS CLI.
-2. Run `make package` to build and upload the build artifact.
-3. Update the `ssosyncv2` CloudFormation stack in the zn-master account using
-   the template file `packaged.yaml` on your local machine.
+2. Run `make deploy` to build, upload and deploy your latest changes

--- a/template.yaml
+++ b/template.yaml
@@ -124,7 +124,7 @@ Resources:
   SSOSyncV2Function:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: provided.al2
+      Runtime: provided.al2023
       Handler: bootstrap
       Architectures:
         - arm64


### PR DESCRIPTION
The runtime was already migrated, but I am now upgrading to the latest provided runtime along with upgrading the Go version and clarifying the way to deploy in the README.md